### PR TITLE
Check if cert split is defined

### DIFF
--- a/lib/kontena/machine/aws/master_provisioner.rb
+++ b/lib/kontena/machine/aws/master_provisioner.rb
@@ -119,7 +119,9 @@ module Kontena::Machine::Aws
         provider: 'aws',
         version: master_version
       }
-      data[:ssl_certificate] = certificate_public_key(ssl_cert) unless opts[:ssl_cert]
+      if self.respond_to?(:certificate_public_key)
+        data[:ssl_certificate] = certificate_public_key(ssl_cert) unless opts[:ssl_cert]
+      end
 
       data
     end


### PR DESCRIPTION
Added a check if the `certificate_public_key` method is defined as it's will be available in 1.0 kontena-cli gem onwards. With older versions of the kontena-cli this would explode with `undefined method`

ping @jakolehm 