### PR TITLE
Allow nodes to be created without a public IP

### DIFF
--- a/lib/kontena/plugin/aws/nodes/create_command.rb
+++ b/lib/kontena/plugin/aws/nodes/create_command.rb
@@ -16,7 +16,7 @@ module Kontena::Plugin::Aws::Nodes
     option "--storage", "STORAGE", "Storage size (GiB)"
     option "--count", "COUNT", "How many instances to create"
     option "--version", "VERSION", "Define installed Kontena version", default: 'latest'
-    option "--associate-public-ip-address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: true, attribute_name: :associate_public_ip
+    option "--[no-]associate-public-ip-address", :flag, "Whether to associated public IP in case the VPC defaults to not doing it", default: true, attribute_name: :associate_public_ip
     option "--security-groups", "SECURITY GROUPS", "Comma separated list of security groups (names) where the new instance will be attached (default: create grid specific group if not already existing)"
 
     def execute


### PR DESCRIPTION
The way the flag was defined didn't allow to disable it because it's `true` by default. Clamp will detect the flag `--no-associate-public-ip-address` as a way to set this to false which is useful in internal deployments where the nodes shouldn't have a public internet addressable IP.