### PR TITLE
Fix broken node restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ This plugin provides support for AWS EC2 provisioning to Kontena CLI.
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
 
+## Testing
+
+From the plugin directory, run the AWS commands using `bundle exec`.
+
+Example: `bundle exec kontena aws master create`
+
 ## License
 
 Kontena is licensed under the Apache License, Version 2.0. See [LICENSE](LICENSE.txt) for full license text.

--- a/lib/kontena/plugin/aws/nodes/restart_command.rb
+++ b/lib/kontena/plugin/aws/nodes/restart_command.rb
@@ -14,7 +14,7 @@ module Kontena::Plugin::Aws::Nodes
     def execute
       require_current_grid
       node_name = self.name || ask_node
-      node = client.get("grids/#{current_grid}/nodes/#{node_name}")
+      node = client.get("nodes/#{current_grid}/#{node_name}")
 
       aws_access_key = ask_aws_access_key
       aws_secret_key = ask_aws_secret_key


### PR DESCRIPTION
Related to #30, fixes the `kontena aws node restart` command to use the correct API URL.

Also, adding simple testing instructions to `readme.md`.