### PR TITLE
Master terminate confirm only if master instance exists

### DIFF
--- a/lib/kontena/machine/aws/master_destroyer.rb
+++ b/lib/kontena/machine/aws/master_destroyer.rb
@@ -19,15 +19,19 @@ module Kontena
           )
         end
 
-        def run!(name)
+        def master_instance(name)
           instances = ec2.instances({
             filters: [
               {name: 'tag:Name', values: [name]}
             ]
           })
-          abort("Cannot find AWS instance #{name}") if instances.to_a.size == 0
+          abort("Cannot find AWS instance #{name}") if instances.to_a.empty?
           abort("There are multiple instances with name #{name}") if instances.to_a.size > 1
-          instance = instances.first
+          instances.first
+        end
+
+        def run!(name, instance = nil)
+          instance ||= master_instance(name)
           if instance
             spinner "Terminating AWS instance #{name.colorize(:cyan)} " do
               instance.terminate

--- a/lib/kontena/plugin/aws/master/terminate_command.rb
+++ b/lib/kontena/plugin/aws/master/terminate_command.rb
@@ -16,13 +16,15 @@ module Kontena::Plugin::Aws::Master
     def execute
       require_current_grid
 
-      node_name = config.current_master.name
-      confirm_command(node_name) unless forced?
-
       require_relative '../../../machine/aws'
       Aws.use_bundled_cert! if aws_bundled_cert?
 
-      destroyer.run!(node_name)
+      master_name = config.current_master.name
+      master_instance = destroyer.master_instance(master_name)
+
+      confirm_command(master_name) unless forced?
+
+      destroyer.run!(master_name, master_instance)
     rescue Seahorse::Client::NetworkingError => ex
       raise ex unless ex.message.match(/certificate verify failed/)
       exit_with_error Kontena::Machine::Aws.ssl_fail_message(aws_bundled_cert?)


### PR DESCRIPTION
Running `kontena aws master terminate` even when using a master from a different provider asked for confirmation before prompting for tokens or checking if the master exists.

This PR makes `kontena aws master terminate` verify that the instance exists before asking for confirmation.
