### PR TITLE
Allow to specify ami via opts

### DIFF
--- a/lib/kontena/machine/aws/master_provisioner.rb
+++ b/lib/kontena/machine/aws/master_provisioner.rb
@@ -36,8 +36,12 @@ module Kontena::Machine::Aws
         end
       end
 
-      ami = resolve_ami(region)
-      abort('No valid AMI found for region') unless ami
+      if opts[:ami]
+        ami = opts[:ami]
+      else
+        ami = resolve_ami(region)
+        abort('No valid AMI found for region') unless ami
+      end
       opts[:vpc] = default_vpc.vpc_id unless opts[:vpc]
 
       raise "Missing :subnet option" if opts[:subnet].nil?

--- a/lib/kontena/machine/aws/node_provisioner.rb
+++ b/lib/kontena/machine/aws/node_provisioner.rb
@@ -24,8 +24,12 @@ module Kontena::Machine::Aws
 
     # @param [Hash] opts
     def run!(opts)
-      ami = resolve_ami(region)
-      abort('No valid AMI found for region') unless ami
+      if opts[:ami]
+        ami = opts[:ami]
+      else
+        ami = resolve_ami(region)
+        abort('No valid AMI found for region') unless ami
+      end
 
       opts[:vpc] = default_vpc.vpc_id unless opts[:vpc]
 

--- a/lib/kontena/plugin/aws/master/create_command.rb
+++ b/lib/kontena/plugin/aws/master/create_command.rb
@@ -13,6 +13,7 @@ module Kontena::Plugin::Aws::Master
     option "--vault-secret", "VAULT_SECRET", "Secret key for Vault (default: generate random secret)"
     option "--vault-iv", "VAULT_IV", "Initialization vector for Vault (default: generate random iv)"
     option "--mongodb-uri", "URI", "External MongoDB uri (optional)"
+    option "--ami", "AMI", "Which Container Linux AMI to use (default: latest stable)"
 
     def execute
       require 'securerandom'
@@ -33,7 +34,8 @@ module Kontena::Plugin::Aws::Master
         mongodb_uri: mongodb_uri,
         associate_public_ip: associate_public_ip?,
         security_groups: security_groups,
-        initial_admin_code: SecureRandom.hex(16)
+        initial_admin_code: SecureRandom.hex(16),
+        ami: ami
       )
     rescue Seahorse::Client::NetworkingError => ex
       raise ex unless ex.message.match(/certificate verify failed/)

--- a/lib/kontena/plugin/aws/nodes/create_command.rb
+++ b/lib/kontena/plugin/aws/nodes/create_command.rb
@@ -11,6 +11,7 @@ module Kontena::Plugin::Aws::Nodes
     include Kontena::Plugin::Aws::Prompts::Common
 
     option "--count", "COUNT", "How many instances to create"
+    option "--ami", "AMI", "Which Container Linux AMI to use (default: latest stable)"
 
     requires_current_master
 
@@ -33,7 +34,8 @@ module Kontena::Plugin::Aws::Nodes
         key_pair: key_pair,
         count: count,
         associate_public_ip: associate_public_ip?,
-        security_groups: security_groups
+        security_groups: security_groups,
+        ami: ami
       )
     rescue Seahorse::Client::NetworkingError => ex
       raise ex unless ex.message.match(/certificate verify failed/)


### PR DESCRIPTION
Current Container Linux stable (1688.4.0) is broken, this pr adds option to override used ami.